### PR TITLE
Switch old Support Forum link to #test-net channel at Discord

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
             <div class="btn-group w-row">
               <div class="col w-col w-col-3"><a href="https://docs.nano.org/" class="btn button-primary button-outline">Documentation</a></div>
               <div class="col w-col w-col-3"><a href="https://hub.nano.org/i/developer-tools/6" class="btn button-primary button-outline">Developer Tools</a></div>
-              <div class="col w-col w-col-3"><a href="https://forum.nano.org/c/development/14" class="btn button-primary button-outline">Support Forum</a></div>
+              <div class="col w-col w-col-3"><a href="https://discord.com/channels/370266023905198083/766723792964812801" class="btn button-primary button-outline">#test-net (Discord)</a></div>
               <div class="col w-col w-col-3"><a href="https://github.com/nanocurrency/nano-node" class="btn button-primary button-outline">GitHub</a></div>
             </div>
           </div>


### PR DESCRIPTION
test.nano.org link change to #test-net at Discord instead of the old support forum.